### PR TITLE
Fix severe performance regression with pest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,9 +201,9 @@ checksum = "9fa00462b37ead6d11a82c9d568b26682d78e0477dc02d1966c013af80969739"
 
 [[package]]
 name = "pest"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab62d2fa33726dbe6321cc97ef96d8cde531e3eeaf858a058de53a8a6d40d8f"
+checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
 dependencies = [
  "thiserror",
  "ucd-trie",

--- a/examples/pest-app/Cargo.toml
+++ b/examples/pest-app/Cargo.toml
@@ -8,4 +8,4 @@ name = "pest-app"
 path = "app.rs"
 
 [dependencies]
-pest = "2.5.4"
+pest = "2.5.5"


### PR DESCRIPTION
I was surprised to see that the `pest-app` example takes so long. Here are the results from my local run:

```json
        "results": [
          {
            "command": "target\\release\\pest-app.exe C:\\Users\\jay\\other-projects\\parse-rosetta-rs\\third_party\\nativejson-benchmark\\data\\canada.json",
            "mean": 322.859203354,
            "stddev": 0.6320329143003725,
            "median": 323.136210274,
            "user": 306.08125,
            "system": 0.5559375,
            "min": 322.092145974,
            "max": 323.45920597400004,
            "times": [
              323.45920597400004,
              323.336535774,
              322.271918774,
              323.136210274,
              322.092145974
            ],
            "exit_codes": [
              0,
              0,
              0,
              0,
              0
            ]
          }
        ]
```

`git bisect` blames 1c98b7132180221e62c07951a3c6ba296f25f57e for the regression. Which is even more surprising!

https://github.com/pest-parser/pest/pull/785 fixes the regression, so we just need to update the crate. The new results with this patch are much saner:

```json
        "results": [
          {
            "command": "target\\release\\pest-app.exe C:\\Users\\jay\\other-projects\\parse-rosetta-rs\\third_party\\nativejson-benchmark\\data\\canada.json",
            "mean": 1.289626222,
            "stddev": 0.01853256087368936,
            "median": 1.286065502,
            "user": 0.740625,
            "system": 0.45531250000000006,
            "min": 1.2703764020000001,
            "max": 1.3205274020000002,
            "times": [
              1.3205274020000002,
              1.286800902,
              1.284360902,
              1.286065502,
              1.2703764020000001
            ],
            "exit_codes": [
              0,
              0,
              0,
              0,
              0
            ]
          }
        ]
```