### PR TITLE
fix(toml): re-order deps so logos is first

### DIFF
--- a/examples/logos-app/Cargo.toml
+++ b/examples/logos-app/Cargo.toml
@@ -8,5 +8,5 @@ name = "logos-app"
 path = "app.rs"
 
 [dependencies]
-ariadne = "0.4.0"
 logos = "0.13.0"
+ariadne = "0.4.0"

--- a/examples/logos-app/Cargo.toml
+++ b/examples/logos-app/Cargo.toml
@@ -8,5 +8,5 @@ name = "logos-app"
 path = "app.rs"
 
 [dependencies]
-logos = "0.13.0"
+logos = "0.14.0"
 ariadne = "0.4.0"


### PR DESCRIPTION
Hello!

I just noticed that your `bench.py` script assume the first dependency to be the tested package, which causes errors in the results table (e.g., version is wrong).

This fixes that issue :-)