### PR TITLE
Reconfigured chumsky example to be more idiomatically geared toward performance

### DIFF
--- a/examples/chumsky-app/parser.rs
+++ b/examples/chumsky-app/parser.rs
@@ -18,29 +18,21 @@ pub enum Json {
 
 pub fn parser<'a>() -> impl Parser<'a, &'a str, Json> {
     recursive(|value| {
-        let digits = one_of('0'..='9').repeated();
-
-        let int = one_of('1'..='9')
-            .then(one_of('0'..='9').repeated())
-            .ignored()
-            .or(just('0').ignored())
-            .ignored();
-
-        let frac = just('.').then(digits.clone());
+        let frac = just('.').then(text::digits(10));
 
         let exp = one_of("eE")
             .then(one_of("+-").or_not())
-            .then(digits.clone());
+            .then(text::digits(10));
 
         let number = just('-')
             .or_not()
-            .then(int)
+            .then(text::int(10))
             .then(frac.or_not())
             .then(exp.or_not())
             .to_slice()
             .map(|s: &str| s.parse().unwrap());
 
-        let escape = just('\\').then_ignore(choice((
+        let escape = just('\\').ignore_then(choice((
             just('\\'),
             just('/'),
             just('"'),


### PR DESCRIPTION
Hopefully you'll agree that nothing here is leaning too aggressively into the benchmark in question: just removing the 'frilly extras' that chumsky provides that favour error quality over performance (the implementation is copied almost verbatim from chumsky's benchmarks, albeit adjusted to take `&str` as input instead of `&[u8]` and with zero-copy features removed to be consistent with the existing benchmarks here).

I've not updated the benchmark results, I'll leave you to do that so as to make sure they're consistent with your setup.

Edit: I realise that the change isn't *quite* equivalent regarding unicode codepoint parsing: if you think that it's likely to have sufficient impact on the benchmarks and would like me to adjust it, I can do so.