### PR TITLE
parol parser: trim parse tree during parser generation

### DIFF
--- a/examples/parol-app/app.rs
+++ b/examples/parol-app/app.rs
@@ -15,14 +15,10 @@ fn main() {
 
     let mut json_grammar = grammar::Grammar::new();
     match parser::parse(&src, &path, &mut json_grammar) {
-        Ok(json) => {
+        Ok(_) => {
             #[cfg(debug_assertions)]
             {
-                println!("{:#?}", json);
-            }
-            #[cfg(not(debug_assertions))]
-            {
-                std::hint::black_box(json);
+                println!("{}", json_grammar);
             }
         }
         Err(err) => {

--- a/examples/parol-app/parser.rs
+++ b/examples/parol-app/parser.rs
@@ -319,6 +319,8 @@ where
         TERMINAL_NAMES,
         NON_TERMINALS,
     );
+    llk_parser.trim_parse_tree();
+
     // Initialize wrapper
     let mut user_actions = GrammarAuto::new(user_actions);
     llk_parser.parse(

--- a/examples/parol-app/tests/codegen.rs
+++ b/examples/parol-app/tests/codegen.rs
@@ -14,6 +14,7 @@ fn codegen() {
     builder.grammar_file("json.par");
     builder.parser_output_file("parser.rs");
     builder.actions_output_file("grammar_trait.rs");
+    builder.trim_parse_tree();
     builder.generate_parser().unwrap();
 
     for entry in std::fs::read_dir(&output_dir).unwrap() {


### PR DESCRIPTION
The generation of parse trees during parsing process in parol is optional. Because this extra parse result (besides the `json_grammar` variable that received the complete parse result already) is constly an therefore disabled mostly.
See also the [example](https://github.com/jsinger67/parol/blob/main/examples/json_parser/main.rs) in the parol crate from where the parol-app was created. Here this parse tree is discared too and the generated `jsons_parser.rs` also contains the call to `trim_parse_tree` to the generated parser.
Nearly all users of parol don't use the parse tree and therefore disabled its creation.
As an example you can have a look at [veryl](https://github.com/veryl-lang/veryl/blob/master/crates/parser/build.rs), where the `trim_parse_tree` function is called on the build in `build.rs`.
This change will not bring parol to the top three but rather may shrink the distance to the second slowest parser a little bit.