### PR TITLE
Add lelwel again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -523,7 +523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -798,6 +798,26 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lelwel"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02f137b31922f1bbf9be8f857ef72dad2fe7b69fec11de207a0ae64a936ceec9"
+dependencies = [
+ "codespan-reporting",
+ "logos",
+ "rustc-hash",
+]
+
+[[package]]
+name = "lelwel-app"
+version = "0.0.0"
+dependencies = [
+ "codespan-reporting",
+ "lelwel",
+ "logos",
+]
 
 [[package]]
 name = "libc"
@@ -1473,7 +1493,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1735,7 +1755,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1744,7 +1764,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2111ef44dae28680ae9752bb89409e7310ca33a8c621ebe7b106cf5c928b3ac0"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2077,7 +2097,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repo tries to assess Rust parsing performance.
 | [combine]  | combinators   | in source   | library            | `&str`                  | ?                      | ?                   | ?               |
 | [grmtools] | CFG           | in grammar  | library            | ?                       | ?                      | ?                   | ?               |
 | [lalrpop]  | LR(1)         | in grammar  | build script       | `&str`                  | none                   | Yes                 | No              |
+| [lelwel]   | LL(1)         | in source   | build script       | `&str`                  | [pratt][lelwel-pratt]  | No                  | No              |
 | [logos]    | lexer         | in source   | proc macro         | `&str`, `&[u8]`         | ?                      | ?                   | ?               |
 | [nom]      | combinators   | in source   | library            | `&str`, `&[u8]`, custom | [pratt][nom-pratt]     | Yes                 | Yes             |
 | [parol]    | LL(k)/LALR(1) | in source   | build script       | `&str`                  | climbing               | No                  | No              |
@@ -18,7 +19,6 @@ This repo tries to assess Rust parsing performance.
 
 Formerly, we compared:
 - [pom]: lack of notoriety
-- [lelwel]: example is too different than others
 
 # Results
 
@@ -29,6 +29,7 @@ grmtools | 2,777 KiB | 11s | 180ms | ![Download count](https://img.shields.io/cr
 chumsky | 161 KiB | 5s | 46ms | ![Download count](https://img.shields.io/crates/dr/chumsky) | v0.12.0
 combine | 175 KiB | 4s | 53ms | ![Download count](https://img.shields.io/crates/dr/combine) | v3.8.1
 lalrpop | 1,522 KiB | 12s | 39ms | ![Download count](https://img.shields.io/crates/dr/lalrpop) | v0.23.0
+lelwel | - | - | - | ![Download count](https://img.shields.io/crates/dr/lelwel) | v0.10.4
 logos | 71 KiB | 6s | 22ms | ![Download count](https://img.shields.io/crates/dr/logos) | v0.16.1
 nom | 88 KiB | 3s | 68ms | ![Download count](https://img.shields.io/crates/dr/nom) | v8.0.0
 parol | 480 KiB | 9s | 183ms | ![Download count](https://img.shields.io/crates/dr/parol) | v4.3.5
@@ -56,6 +57,7 @@ $ ./format.py
 [combine]: https://github.com/Marwes/combine
 [lalrpop]: https://github.com/lalrpop/lalrpop
 [lelwel]: https://github.com/0x2a-42/lelwel
+[lelwel-pratt]: https://github.com/0x2a-42/lelwel?tab=readme-ov-file#direct-left-recursion
 [logos]: https://github.com/maciejhirsz/logos
 [nom]: https://github.com/geal/nom
 [nom-pratt]: https://docs.rs/nom-language/latest/nom_language/precedence/fn.precedence.html

--- a/examples/lelwel-app/Cargo.toml
+++ b/examples/lelwel-app/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "lelwel-app"
+edition.workspace = true
+
+[[bin]]
+name = "lelwel-app"
+path = "app.rs"
+
+[dependencies]
+codespan-reporting = "0.13.1"
+logos = "0.16.1"
+
+[build-dependencies]
+lelwel = "0.10.4"
+
+[lints]
+workspace = true

--- a/examples/lelwel-app/app.rs
+++ b/examples/lelwel-app/app.rs
@@ -1,0 +1,106 @@
+mod lexer;
+mod parser;
+
+use std::{env, fs};
+
+use codespan_reporting::diagnostic::Severity;
+use codespan_reporting::files::SimpleFile;
+use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
+use codespan_reporting::term::{self, Config};
+use lexer::Token;
+use parser::*;
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub enum Value {
+    Null,
+    Bool(bool),
+    Number(f64),
+    String(String),
+    Array(Vec<Value>),
+    Object(HashMap<String, Value>),
+}
+
+impl Cst<'_> {
+    pub fn to_value(&self, node_ref: NodeRef) -> Option<Value> {
+        match self.get(node_ref) {
+            Node::Rule(rule, _) => match rule {
+                Rule::File => self
+                    .children(node_ref)
+                    .find_map(|child_node_ref| self.to_value(child_node_ref)),
+                Rule::Literal => self.to_value(self.children(node_ref).next()?),
+                Rule::Array => Some(Value::Array(
+                    self.children(node_ref)
+                        .filter_map(|child_node_ref| self.to_value(child_node_ref))
+                        .collect(),
+                )),
+                Rule::Object => {
+                    let mut members = HashMap::new();
+                    for mut member_node_refs in self
+                        .children(node_ref)
+                        .filter(|&child_node_ref| self.match_rule(child_node_ref, Rule::Member))
+                        .map(|child_node_ref| self.children(child_node_ref))
+                    {
+                        let Some(key) = member_node_refs
+                            .find_map(|member_node_ref| {
+                                self.match_token(member_node_ref, Token::String)
+                            })
+                            .map(|(key_str, _)| key_str[1..key_str.len() - 1].to_owned())
+                        else {
+                            continue;
+                        };
+                        let Some(val) = member_node_refs
+                            .find_map(|member_node_ref| self.to_value(member_node_ref))
+                        else {
+                            continue;
+                        };
+                        members.insert(key, val);
+                    }
+                    Some(Value::Object(members))
+                }
+                _ => None,
+            },
+            Node::Token(token, idx) => match token {
+                Token::String => {
+                    let val = self.span_text(idx);
+                    Some(Value::String(val[1..val.len() - 1].to_owned()))
+                }
+                Token::Number => Some(Value::Number(str::parse(self.span_text(idx)).ok()?)),
+                Token::True => Some(Value::Bool(true)),
+                Token::False => Some(Value::Bool(false)),
+                Token::Null => Some(Value::Null),
+                _ => None,
+            },
+        }
+    }
+}
+
+fn main() {
+    let path = env::args().nth(1).expect("Expected file argument");
+    let src = fs::read_to_string(&path).expect("Failed to read file");
+
+    let mut diags = vec![];
+    let cst = Parser::new(&src, &mut diags).parse(&mut diags);
+    let json = cst.to_value(NodeRef::ROOT);
+
+    #[cfg(debug_assertions)]
+    {
+        println!("{:#?}", json);
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        std::hint::black_box(json);
+    }
+
+    if !diags.is_empty() {
+        let writer = StandardStream::stderr(ColorChoice::Auto);
+        let config = Config::default();
+        let file = SimpleFile::new(&path, &src);
+        for diag in diags.iter() {
+            term::emit_to_write_style(&mut writer.lock(), &config, &file, diag).unwrap();
+        }
+        if diags.iter().any(|d| d.severity == Severity::Error) {
+            std::process::exit(1);
+        }
+    }
+}

--- a/examples/lelwel-app/build.rs
+++ b/examples/lelwel-app/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    lelwel::build("json.llw");
+}

--- a/examples/lelwel-app/json.llw
+++ b/examples/lelwel-app/json.llw
@@ -1,0 +1,25 @@
+token True='true' False='false' Null='null';
+token LBrace='{' RBrace='}' LBrak='[' RBrak=']' Comma=',' Colon=':';
+token String='<string>' Number='<number>';
+token Whitespace;
+
+skip Whitespace;
+
+start file;
+
+file: value;
+value^:
+  object
+| array
+| literal
+;
+object: '{' [member (',' member)*] '}';
+member: String ':' value;
+array: '[' [value (',' value)*] ']';
+literal:
+  String
+| Number
+| 'true'
+| 'false'
+| 'null'
+;

--- a/examples/lelwel-app/lexer.rs
+++ b/examples/lelwel-app/lexer.rs
@@ -1,0 +1,168 @@
+use crate::parser::{Diagnostic, Span};
+use codespan_reporting::diagnostic::Label;
+use logos::{Lexer, Logos};
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum LexerError {
+    #[default]
+    Invalid,
+    UnterminatedString,
+}
+
+impl LexerError {
+    pub fn into_diagnostic(self, span: Span) -> Diagnostic {
+        match self {
+            Self::Invalid => Diagnostic::error()
+                .with_message("invalid token")
+                .with_label(Label::primary((), span)),
+            Self::UnterminatedString => Diagnostic::error()
+                .with_message("unterminated string")
+                .with_label(Label::primary((), span)),
+        }
+    }
+}
+
+fn parse_string(lexer: &mut Lexer<'_, Token>) -> Result<(), LexerError> {
+    let mut it = lexer.remainder().chars();
+    while let Some(c) = it.next() {
+        match c {
+            '"' => {
+                lexer.bump(1);
+                return Ok(());
+            }
+            '\\' => {
+                lexer.bump(1);
+                if let Some(c) = it.next() {
+                    lexer.bump(c.len_utf8());
+                }
+            }
+            c => {
+                lexer.bump(c.len_utf8());
+            }
+        }
+    }
+    Err(LexerError::UnterminatedString)
+}
+
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Logos, Debug, PartialEq, Copy, Clone)]
+#[logos(error = LexerError)]
+pub enum Token {
+    EOF,
+    #[regex("[\u{0020}\u{000A}\u{000D}\u{0009}]+")]
+    Whitespace,
+    #[token("true")]
+    True,
+    #[token("false")]
+    False,
+    #[token("null")]
+    Null,
+    #[token("{")]
+    LBrace,
+    #[token("}")]
+    RBrace,
+    #[token("[")]
+    LBrak,
+    #[token("]")]
+    RBrak,
+    #[token(",")]
+    Comma,
+    #[token(":")]
+    Colon,
+    #[regex("\"", parse_string)]
+    String,
+    #[regex(r"-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?")]
+    Number,
+    #[regex(r"[a-zA-Z][a-zA-Z0-9]*", |_| false)]
+    Error,
+}
+
+fn check_string(value: &str, span: &Span, diags: &mut Vec<Diagnostic>) {
+    let mut it = value.char_indices();
+    while let Some((i, c)) = it.next() {
+        match c {
+            '\\' => match it.next() {
+                Some((_, '"' | '\\' | '/' | 'b' | 'f' | 'n' | 'r' | 't')) => {}
+                Some((i, 'u')) => {
+                    for j in 0..4 {
+                        if !it
+                            .next()
+                            .map(|(_, c)| c.is_ascii_hexdigit())
+                            .unwrap_or(false)
+                        {
+                            diags.push(
+                                Diagnostic::error()
+                                    .with_message("invalid unicode escape sequence")
+                                    .with_label(Label::primary(
+                                        (),
+                                        span.start + i - 1..span.start + i + j + 1,
+                                    )),
+                            );
+                            break;
+                        }
+                    }
+                }
+                Some((j, _)) => {
+                    diags.push(
+                        Diagnostic::error()
+                            .with_message("invalid escape sequence")
+                            .with_label(Label::primary((), span.start + j - 1..span.start + j + 1)),
+                    );
+                }
+                _ => unreachable!(),
+            },
+            '\u{0020}'..='\u{10FFFF}' => {}
+            c => {
+                diags.push(
+                    Diagnostic::error()
+                        .with_message(format!("string contains invalid character {c:?}"))
+                        .with_label(
+                            Label::primary((), span.start + i..span.start + i + 1)
+                                .with_message("after this character"),
+                        ),
+                );
+            }
+        }
+    }
+}
+
+pub fn tokenize(source: &str, diags: &mut Vec<Diagnostic>) -> (Vec<Token>, Vec<Span>) {
+    let lexer = Token::lexer(source);
+    let mut tokens = vec![];
+    let mut spans = vec![];
+    let source = lexer.source();
+
+    let mut count_brace = 0;
+    let mut count_brak = 0;
+    for (token, span) in lexer.spanned() {
+        match token {
+            Ok(token) => {
+                match token {
+                    Token::String => {
+                        check_string(&source[span.start..span.end], &span, diags);
+                    }
+                    Token::LBrace => count_brace += 1,
+                    Token::RBrace => count_brace -= 1,
+                    Token::LBrak => count_brak += 1,
+                    Token::RBrak => count_brak -= 1,
+                    _ => {}
+                }
+                if count_brace + count_brak > 256 {
+                    diags.push(
+                        Diagnostic::error()
+                            .with_message("bracket nesting level exceeded maximum of 256")
+                            .with_label(Label::primary((), span)),
+                    );
+                    break;
+                }
+                tokens.push(token);
+            }
+            Err(err) => {
+                diags.push(err.into_diagnostic(span.clone()));
+                tokens.push(Token::Error);
+            }
+        }
+        spans.push(span);
+    }
+    (tokens, spans)
+}

--- a/examples/lelwel-app/parser.rs
+++ b/examples/lelwel-app/parser.rs
@@ -1,0 +1,25 @@
+use codespan_reporting::diagnostic::Label;
+
+use crate::lexer::{tokenize, Token};
+
+pub type Diagnostic = codespan_reporting::diagnostic::Diagnostic<()>;
+
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+
+impl<'a> ParserCallbacks<'a> for Parser<'a> {
+    type Diagnostic = Diagnostic;
+    type Context = ();
+
+    fn create_tokens(
+        _context: &mut Self::Context,
+        source: &str,
+        diags: &mut Vec<Diagnostic>,
+    ) -> (Vec<Token>, Vec<Span>) {
+        tokenize(source, diags)
+    }
+    fn create_diagnostic(&self, span: Span, message: String) -> Diagnostic {
+        Diagnostic::error()
+            .with_message(message)
+            .with_label(Label::primary((), span))
+    }
+}


### PR DESCRIPTION
With https://github.com/0x2a-42/lelwel/pull/63 I have updated the [upstream example](https://github.com/0x2a-42/lelwel/tree/main/examples/json) to create an owned JSON value instead of just a CST. Therefore it should now be more comparable to the other examples in this repository. As the parser still creates an additional CST, it now actually does more work than the other parsers, but I guess that's fine. Maybe we could add an additional column to the table, to denote this fact.

The example now also uses a `build.rs` file, which probably slows down the build, but is more representative of how the library is normally used.