### PR TITLE
Improve feature matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,40 @@
 
 This repo tries to assess Rust parsing performance.
 
-| crate      | parser type   | action code | integration        | input type              | precedence             | parameterized rules | streaming input |
-|------------|---------------|-------------|--------------------|-------------------------|------------------------|---------------------|-----------------|
-| [chumsky]  | combinators   | in source   | library            | `&str`, `&[u8]`, custom | [pratt][chumsky-pratt] | Yes                 | Yes             |
-| [combine]  | combinators   | in source   | library            | `&str`                  | ?                      | ?                   | ?               |
-| [grmtools] | CFG           | in grammar  | library            | ?                       | ?                      | ?                   | ?               |
-| [lalrpop]  | LR(1)         | in grammar  | build script       | `&str`                  | none                   | Yes                 | No              |
-| [lelwel]   | LL(1)         | in source   | build script       | `&str`                  | [pratt][lelwel-pratt]  | No                  | No              |
-| [logos]    | lexer         | in source   | proc macro         | `&str`, `&[u8]`         | ?                      | ?                   | ?               |
-| [nom]      | combinators   | in source   | library            | `&str`, `&[u8]`, custom | [pratt][nom-pratt]     | Yes                 | Yes             |
-| [parol]    | LL(k)/LALR(1) | in source   | build script       | `&str`                  | climbing               | No                  | No              |
-| [peg]      | PEG           | in grammar  | proc macro (block) | `&str`, `&[T]`, custom  | climbing               | Yes                 | No              |
-| [pest]     | PEG           | external    | proc macro (file)  | `&str`                  | climbing               | No                  | No              |
-| [winnow]   | combinators   | in source   | library            | `&str`, `&[T]`, custom  | none                   | Yes                 | Yes             |
-| [yap]      | combinators   | in source   | library            | `&str`, `&[T]`, custom  | none                   | Yes                 | ?               |
+| crate      | parser type   | action code | integration        | input type              |
+|------------|---------------|-------------|--------------------|-------------------------|
+| [chumsky]  | combinators   | in source   | library            | `&str`, `&[u8]`, custom |
+| [combine]  | combinators   | in source   | library            | `&str`                  |
+| [grmtools] | CFG           | in grammar  | library            | ?                       |
+| [lalrpop]  | LR(1)         | in grammar  | build script       | `&str`                  |
+| [lelwel]   | LL(1)         | in source   | build script       | `&str`                  |
+| [logos]    | lexer         | in source   | proc macro         | `&str`, `&[u8]`         |
+| [nom]      | combinators   | in source   | library            | `&str`, `&[u8]`, custom |
+| [parol]    | LL(k)/LALR(1) | in source   | build script       | `&str`                  |
+| [peg]      | PEG           | in grammar  | proc macro (block) | `&str`, `&[T]`, custom  |
+| [pest]     | PEG           | external    | proc macro (file)  | `&str`                  |
+| [winnow]   | combinators   | in source   | library            | `&str`, `&[T]`, custom  |
+| [yap]      | combinators   | in source   | library            | `&str`, `&[T]`, custom  |
 
 Formerly, we compared:
 - [pom]: lack of notoriety
+
+# Features
+
+| crate    | operator precedence    | parameterized rules | streaming input | lossless syntax tree
+|----------|------------------------|---------------------|-----------------|---------------------
+| chumsky  | [pratt][chumsky-pratt] | ✅                  | ✅              | ❌
+| combine  | ?                      | ?                   | ?               | ❌
+| grmtools | ?                      | ?                   | ?               | ❌
+| lalrpop  | ❌                     | ✅                  | ❌              | ❌
+| lelwel   | [pratt][lelwel-pratt]  | ❌                  | ❌              | ✅
+| logos    | ❌                     | ❌                  | ?               | ❌
+| nom      | [pratt][nom-pratt]     | ✅                  | ✅              | ❌
+| parol    | ❌                     | ❌                  | ❌              | ✅
+| peg      | climbing               | ✅                  | ❌              | ❌
+| pest     | climbing               | ❌                  | ❌              | ❌
+| winnow   | ❌                     | ✅                  | ✅              | ❌
+| yap      | ❌                     | ✅                  | ?               | ❌
 
 # Results
 


### PR DESCRIPTION
I tried to improve the readability of the feature matrix.
- I replaced words like "No", "Yes", and "none" by symbols, which makes it easier to quickly scan the table.
- I moved the features to a separate table to avoid a cutoff due to the narrow layout of the readme on github. This also leaves some room to compare more features in the future.

While I was at it, I also made the following changes.
- There is now a column for "lossless syntax tree" support, i.e. a syntax tree that contains all the information of the original source file, including location and content of whitespace and comments. This is useful when writing parsers for language servers and formatters. As far as I could tell only `lelwel` and `parol` (via. `syntree`) support this.
- I removed the "climbing" entry for `parol`, as it seems to require encoding operator precedence and associativity in the grammar rules (CC: @jsinger67).
- I filled in the "precedence" and "parameterized rules" columns for `logos`, which are not relevant for a lexer generator.